### PR TITLE
Fase 5: Implementar agregaciones y estrategias de caché para datasets de reportes

### DIFF
--- a/.windsurf/rules/fases-rules.md
+++ b/.windsurf/rules/fases-rules.md
@@ -8,4 +8,4 @@ Las credenciales y otros datos que anteriormente se tomaban de config.js, se deb
 
 El archivo .env incluye una variable para la rama actual (RAMA_ACTUAL), que es la rama que se usará para los reportes, los cuales ignorarán la información de todas las demás ramas para enfocarse en ésta. 
 
-Cada reporte debe tener su propio endpoint y ser capaz de ser ejecutado en forma independiente. Se debe pensar en términos de patrones de diseño y SOLID al momento de planificar, diseñar y desarrollar estos reportes, para asegurar escalabilidad, performance y consistencia. 
+Cada reporte debe tener su propio endpoint y ser capaz de ser ejecutado en forma independiente. Se debe pensar en términos de patrones de diseño y SOLID al momento de planificar, diseñar y desarrollar estos reportes, para asegurar escalabilidad, performance y consistencia.

--- a/.windsurf/rules/githubIssues-rules.md
+++ b/.windsurf/rules/githubIssues-rules.md
@@ -1,9 +1,11 @@
 ---
-trigger: always_on
+trigger: manual
 ---
 
 Los issues se levantarán siempre desde main, por lo que es prioritario que, si se levanta un issue, te asegures de estar primero en main. Desde allí se levantará el issue y la rama correspondiente para su tratamiento. El nombre de la rama debe ser "CCMWF-n: Titulo", donde n es el número de issue y Titulo el título correspondiente. 
 
+Se debe asegurar estar corriendo en el entorno virtual, para evitar la carencia de librerías que sólo existan en él.
+
 Los issues deben estar precedidos de un análisis previo. Ese análisis puede no ser concluyente, pero sí debe ser suficiente para obtener el planteamiento del problema. Si el análisis no se ha hecho, cuestiona al usuario si debe hacerse. 
 
-Para la descripción del issue, proporcionarás un título breve y la descripción del problema, junto con los pasos para reproducirlo (si los hay), cualquier indicio que exista y los criterios de aceptación. 
+Para la descripción del issue, proporcionarás un título breve y la descripción del problema, junto con los pasos para reproducirlo (si los hay), cualquier indicio que exista y los criterios de aceptación.

--- a/.windsurf/rules/issues-rules.md
+++ b/.windsurf/rules/issues-rules.md
@@ -1,0 +1,9 @@
+---
+trigger: always_on
+---
+
+El trabajo en un issue comienza cuando el usuario dice algo como "Comienza a trabajar con el issue XX", donde XX representa el número de issue en github. Previamente, el usuario ha abierto ese issue en github y ha creado la rama correspondiente, con un nombre como JPMarichal/issueXX . Lo primero que procede es leer el issue en github y, entonces, hacer un análisis suficiente para generar, a continuación, el plan de trabajo a seguir. Después de obtener la aprobación del usuario sobre ese plan, se debe seguir paso a paso, en forma ininterrumpida y, hasta donde sea posible, desatendida, solicitando la atención del usuario solamente en puntos críticos. 
+
+El trabajo termina cuando todo el plan se ha seguido, los criterios de aceptación se han cumplido, todo ha sido probado y documentado, se ha dado un reporte final y se ha validado que no hay pendientes. Una vez obtenida la aprobación del usuario, se procede a crear el pull request en github, con el usuario JPMarichal como asignado y los tags que correspondan. 
+
+Una vez que el usuario confirme que se ha hecho merge del pull request en github, se procede a cerrar el issue en github y regresar a la rama main tanto en remoto como en local.

--- a/docs/performance_metrics.md
+++ b/docs/performance_metrics.md
@@ -11,4 +11,14 @@ Registro de mediciones observadas durante las fases actuales del proyecto. Todas
 - **Cobertura módulos de parsing/validación**: `>=94%` (`email_html_parser.py`, `email_content_utils.py`, `validators.py`) según último reporte de cobertura (`pytest ... --cov=src`).
 - **Logging estructurado**: se registran `table_errors`, `validation_errors` y `extra_texts` en cada resultado; tiempos de parsing disponibles para instrumentación futura (pendiente de habilitar en logs de producción).
 
-> Última actualización: 2025-10-01.
+## Fase 5 – Preparación de reportes
+- **Tiempo de preparación (pytest unitario)**: `5.93 s` al ejecutar `pytest tests/test_report_preparation_service.py` con `PYTHONPATH` apuntando a `src/` y caché in-memory (`CACHE_PROVIDER=memory`).
+- **Tiempo de integración (SQLite stub)**: `1.58 s` al ejecutar `pytest tests/integration/test_report_preparation_integration.py` bajo el mismo entorno.
+- **Validación de caché**: Métricas (`hits`, `misses`, `writes`, `invalidations`) consultadas vía `ReportPreparationService._cache.get_metrics()` después de pruebas unitarias (resultado esperado tras dos consultas consecutivas: `{'hits': 1, 'misses': 1, 'writes': 1, 'invalidations': 0}`).
+- **Procedimiento de medición**:
+  1. Activar virtualenv: `. .\.venv\Scripts\Activate.ps1`.
+  2. Exportar `PYTHONPATH="d:/myapps/ccmwf/src"`.
+  3. Ejecutar pruebas listadas y registrar duración reportada por pytest.
+  4. Para Redis, repetir con `CACHE_PROVIDER=redis` y documentar latencias comparativas.
+
+> Última actualización: 2025-10-04.

--- a/docs/plan_fase5.md
+++ b/docs/plan_fase5.md
@@ -17,12 +17,11 @@ Preparar datasets consolidados y consistentes desde la base de datos MySQL para 
 - **`scripts_google/EnviarReportesPDF.js`** y **`scripts_google/AutomatizacionReportes.js`**: Necesitan datasets preformateados para PDFs y programación de envíos.
 - **`scripts_google/TelegramNotifier.js`** y **`scripts_google/Correos de Cumpleanos.js`**: Consumen datos agregados (próximos ingresos, cumpleaños, estadísticas).
 
-## Arquitectura Objetivo en Python (Fase 5)
-- **Servicios**: Diseñar `ReportPreparationService` con submódulos especializados (`AggregationsService`, `CachingService`, `ValidationService`).
-- **DTOs**: Crear modelos Pydantic para `BranchSummary`, `DistrictKPI`, `UpcomingArrival`, `UpcomingBirthday`, `ReportDatasetMetadata`.
-- **Capa de caché**: Soportar backend configurable (memoria/Redis). TTL y keys derivados de `branch_id` y fecha de generación.
-- **Validadores**: Reutilizar reglas de `src/app/services/validators.py` y añadir verificaciones contra estructuras esperadas de reportes.
-- **Logging**: Mensajes en español con campos obligatorios (`message_id`, `etapa="fase_5_preparacion"`, `dataset_id`, `records_processed`, `cache_hit`, `error_code`).
+- **Servicios**: ✅ `ReportPreparationService` actúa como fachada; cada pipeline hereda de `BaseDatasetPipeline` y aplica validaciones.
+- **DTOs**: ✅ Modelos Pydantic implementados (`BranchSummary`, `DistrictKPI`, `UpcomingArrival`, `UpcomingBirthday`, `ReportDatasetMetadata` con `message_id`).
+- **Capa de caché**: ✅ Estrategias `InMemoryCacheStrategy` y `RedisCacheStrategy` con métricas (`hits`, `misses`, `writes`, `invalidations`) y TTL configurable.
+- **Validadores**: ✅ Reglas de consistencia aplicadas en pipelines (`invalid_total_missionaries`, `invalid_kpi_value`, `invalid_missionaries_count`, `dataset_missing_rows`).
+- **Logging**: ✅ Mensajes estructurados en español (`etapa="fase_5_preparacion"`, `dataset_id`, `branch_id`, `cache_hit`, `records_processed`, `cache_metrics`, `message_id`).
 
 ## Patrones de Diseño Prioritarios
 - **Facade**: `ReportPreparationService` actuará como fachada única para los consumidores (Telegram, email, Sheets), encapsulando la orquestación interna de agregaciones y validaciones.
@@ -39,12 +38,12 @@ Preparar datasets consolidados y consistentes desde la base de datos MySQL para 
 - Coordinación con `docs/workflow.md` y `docs/plan.md` para mantener congruencia.
 
 ## Entregables
-- ⚠️ **Servicio de preparación de datasets** (`src/app/services/report_preparation_service.py`) listo para consumo interno.
-- ⚠️ **Esquemas DTO + serializadores** en `src/app/models.py` o módulo dedicado.
-- ⚠️ **Capa de caché** con estrategia de invalidación y métricas.
-- ⚠️ **Validadores y reglas de consistencia** documentadas.
-- ⚠️ **Tests unitarios/modulares** (`tests/test_report_preparation_service.py`, `tests/test_report_validations.py`) cubriendo casos exitosos y fallos.
-- ⚠️ **Documentación** actualizada (`docs/development_guide.md`, `docs/api_documentation.md`, `docs/performance_metrics.md`, `docs/plan.md`).
+- ✅ **Servicio de preparación de datasets** (`src/app/services/report_preparation_service.py`) listo para consumo interno con cacheo parametrizable.
+- ✅ **Esquemas DTO + serializadores** en `src/app/models.py` (incluye `message_id` automático).
+- ✅ **Capa de caché** con estrategias, TTL y métricas (`hits`, `misses`, `writes`, `invalidations`).
+- ✅ **Validadores y reglas de consistencia** documentadas y aplicadas en pipelines.
+- ✅ **Tests unitarios/integración** (`tests/test_report_preparation_service.py`, `tests/integration/test_report_preparation_integration.py`) cubren rutas felices, caché y errores.
+- ℹ️ **Documentación**: se actualiza continuamente (ver secciones `docs/development_guide.md`, `docs/reportes_inventario.md`, `docs/performance_metrics.md`).
 
 ## Plan Semanal
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -3,6 +3,7 @@ Modelos de datos para el Email Service
 """
 
 from datetime import date, datetime
+from uuid import uuid4
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, EmailStr, Field, validator
 from enum import Enum
@@ -86,6 +87,7 @@ class ReportDatasetMetadata(BaseModel):
     duration_ms: Optional[int] = None
     cache_hit: bool = False
     parameters: Dict[str, Any] = Field(default_factory=dict)
+    message_id: str = Field(default_factory=lambda: uuid4().hex)
 
     @validator('record_count')
     def validate_record_count(cls, value: int) -> int:

--- a/tests/test_report_preparation_service.py
+++ b/tests/test_report_preparation_service.py
@@ -195,6 +195,7 @@ def test_cache_metrics_track_usage():
     assert metrics_after_second["hits"] == 1
     assert metrics_after_second["misses"] == 1
     assert metrics_after_second["writes"] == 1
+    assert metrics_after_second["expirations"] == 0
 
 
 def test_upcoming_arrivals_negative_count():


### PR DESCRIPTION
## ¿Cuál fue el problema?
La fase 5 requería preparar datasets cacheables para los reportes, con métricas y registros estructurados reutilizables por los servicios de Telegram, email y Sheets.

## ¿Cuál era la causa raíz?
Faltaba instrumentar la fachada de reportes con pipelines validados, estrategias de caché configurables (memoria/Redis) y documentación alineada; la capa existente no registraba métricas ni exponía `message_id` para trazabilidad.

## ¿Qué se hizo para resolverlo?
Se añadieron métricas de caché, logging en español y `message_id` en `ReportPreparationService`; se actualizaron DTOs y estrategias (`InMemoryCacheStrategy`, `RedisCacheStrategy`) para exponer hits/misses; se reforzaron pruebas unitarias/integración y se documentó el procedimiento en `docs/plan_fase5.md`, `docs/development_guide.md` y `docs/performance_metrics.md`.