### PR TITLE
Fase 5: Validaciones y pruebas de preparación de reportes

### DIFF
--- a/.windsurf/rules/issues-rules.md
+++ b/.windsurf/rules/issues-rules.md
@@ -2,7 +2,9 @@
 trigger: always_on
 ---
 
-El trabajo en un issue comienza cuando el usuario dice algo como "Comienza a trabajar con el issue XX", donde XX representa el número de issue en github. Previamente, el usuario ha abierto ese issue en github y ha creado la rama correspondiente, con un nombre como JPMarichal/issueXX . Lo primero que procede es leer el issue en github y, entonces, hacer un análisis suficiente para generar, a continuación, el plan de trabajo a seguir. Después de obtener la aprobación del usuario sobre ese plan, se debe seguir paso a paso, en forma ininterrumpida y, hasta donde sea posible, desatendida, solicitando la atención del usuario solamente en puntos críticos. 
+El trabajo en un issue comienza cuando el usuario dice algo como "Comienza a trabajar con el issue XX", donde XX representa el número de issue en github. Previamente, el usuario ha abierto ese issue en github y ha creado la rama correspondiente, con un nombre como JPMarichal/issueXX . 
+
+Lo primero que procede es leer el issue en github y, entonces, hacer un análisis suficiente para generar, a continuación, el plan de trabajo a seguir, dividido en pasos funcionales, criterios de aceptación propios y entregables. Después de obtener la aprobación del usuario sobre ese plan, se debe seguir paso a paso, en forma ininterrumpida y, hasta donde sea posible, desatendida, solicitando la atención del usuario solamente en puntos críticos. 
 
 El trabajo termina cuando todo el plan se ha seguido, los criterios de aceptación se han cumplido, todo ha sido probado y documentado, se ha dado un reporte final y se ha validado que no hay pendientes. Una vez obtenida la aprobación del usuario, se procede a crear el pull request en github, con el usuario JPMarichal como asignado y los tags que correspondan. 
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -1,3 +1,8 @@
+- ⚠️ Advertencia técnica: mientras `src/app/models.py` continúe con decoradores `@validator` (Pydantic V1), las ejecuciones de pruebas mostrarán `PydanticDeprecatedSince20`. Registrar el avance de la migración a `@field_validator` en las próximas revisiones.
+- **Reporte de preparación de datasets (Fase 5)**
+  - ℹ️ los servicios internos (`ReportPreparationService`) exponen endpoints FastAPI aún en diseño para la automatización de reportes. Las respuestas estructuradas incluyen metadatos `message_id`, `cache_hit`, `record_count` y códigos de validación (`invalid_branch`, `duplicate_records`, `missing_required_fields`, `stale_cache`, `invalid_total_missionaries`, `invalid_kpi_value`, `invalid_missionaries_count`, `dataset_missing_rows`).
+  - ⚠️ se debe documentar detalladamente cada endpoint cuando sea expuesto públicamente; por ahora el consumo es interno desde servicios y tareas programadas.
+
 # API Documentation - CCM Email Service
 
 ## Overview

--- a/docs/performance_metrics.md
+++ b/docs/performance_metrics.md
@@ -13,12 +13,15 @@ Registro de mediciones observadas durante las fases actuales del proyecto. Todas
 
 ## Fase 5 – Preparación de reportes
 - **Tiempo de preparación (pytest unitario)**: `5.93 s` al ejecutar `pytest tests/test_report_preparation_service.py` con `PYTHONPATH` apuntando a `src/` y caché in-memory (`CACHE_PROVIDER=memory`).
+- **Tiempo de pruebas de validaciones**: `2.40 s` al ejecutar `pytest tests/test_report_preparation_service.py tests/test_report_validations.py` (18 pruebas). Resultado incluye invalidaciones de caché al refrescar entradas obsoletas (`invalidations >= 1`).
 - **Tiempo de integración (SQLite stub)**: `1.58 s` al ejecutar `pytest tests/integration/test_report_preparation_integration.py` bajo el mismo entorno.
-- **Validación de caché**: Métricas (`hits`, `misses`, `writes`, `invalidations`) consultadas vía `ReportPreparationService._cache.get_metrics()` después de pruebas unitarias (resultado esperado tras dos consultas consecutivas: `{'hits': 1, 'misses': 1, 'writes': 1, 'invalidations': 0}`).
+- **Validación de caché**: Métricas (`hits`, `misses`, `writes`, `invalidations`) consultadas vía `ReportPreparationService._cache.get_metrics()`; cuando se fuerza expiración manual se espera al menos una invalidación antes del reproceso.
 - **Procedimiento de medición**:
   1. Activar virtualenv: `. .\.venv\Scripts\Activate.ps1`.
   2. Exportar `PYTHONPATH="d:/myapps/ccmwf/src"`.
   3. Ejecutar pruebas listadas y registrar duración reportada por pytest.
   4. Para Redis, repetir con `CACHE_PROVIDER=redis` y documentar latencias comparativas.
+
+> ⚠️ Observación: mientras `src/app/models.py` utilice decoradores `@validator` (Pydantic V1) las ejecuciones de pruebas reportarán `PydanticDeprecatedSince20`. Dar seguimiento en la migración a `@field_validator`.
 
 > Última actualización: 2025-10-04.

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -113,7 +113,7 @@ class Settings(BaseSettings):
 
     @field_validator('rama_actual', mode='before')
     def parse_rama_actual(cls, value: Any) -> Optional[int]:  # noqa: D401
-        """Convierte la rama actual configurada a entero"""
+        """Converts the configured current branch to an integer"""
         if value is None or value == "":
             return None
         return int(value)

--- a/tests/test_report_validations.py
+++ b/tests/test_report_validations.py
@@ -1,0 +1,162 @@
+"""Pruebas específicas de validaciones para pipelines de Fase 5.
+
+Cada prueba documenta el requisito asociado para mantener trazabilidad
+frente a `docs/plan_fase5.md` y las reglas de testing del proyecto.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, Iterable, List, Optional
+
+import pytest
+
+from app.services.report_data_repository import ReportDataRepository
+from app.services.report_preparation_service import (
+    BaseDatasetPipeline,
+    BranchSummaryPipeline,
+    DatasetValidationError,
+    UpcomingArrivalPipeline,
+    UpcomingBirthdayPipeline,
+)
+
+
+class _ListRepository(ReportDataRepository):
+    """Repositorio mínimo que devuelve listas precargadas."""
+
+    def __init__(
+        self,
+        *,
+        branch_summary_rows: Iterable[Dict[str, Any]] | None = None,
+        district_kpis_rows: Iterable[Dict[str, Any]] | None = None,
+        upcoming_arrivals_rows: Iterable[Dict[str, Any]] | None = None,
+        upcoming_birthdays_rows: Iterable[Dict[str, Any]] | None = None,
+    ) -> None:
+        self.branch_summary_rows = list(branch_summary_rows or [])
+        self.district_kpis_rows = list(district_kpis_rows or [])
+        self.upcoming_arrivals_rows = list(upcoming_arrivals_rows or [])
+        self.upcoming_birthdays_rows = list(upcoming_birthdays_rows or [])
+
+    def fetch_branch_summary(self, branch_id: Optional[int], params: Dict[str, object]) -> Iterable[Dict[str, object]]:
+        return self.branch_summary_rows
+
+    def fetch_district_kpis(self, branch_id: Optional[int], params: Dict[str, object]) -> Iterable[Dict[str, object]]:
+        return self.district_kpis_rows
+
+    def fetch_upcoming_arrivals(self, branch_id: Optional[int], params: Dict[str, object]) -> Iterable[Dict[str, object]]:
+        return self.upcoming_arrivals_rows
+
+    def fetch_upcoming_birthdays(self, branch_id: Optional[int], params: Dict[str, object]) -> Iterable[Dict[str, object]]:
+        return self.upcoming_birthdays_rows
+
+
+class _SimplePipeline(BaseDatasetPipeline):
+    """Pipeline de prueba que expone validaciones básicas."""
+
+    dataset_id = "simple_dataset"
+    required_fields = ("id", "value")
+
+    def __init__(self, *, rows: Iterable[Dict[str, Any]]) -> None:
+        super().__init__(repository=_ListRepository())
+        self._rows = list(rows)
+
+    def _load(self) -> Iterable[Dict[str, Any]]:
+        return self._rows
+
+
+def test_branch_summary_pipeline_detects_duplicates():
+    """✅ `BranchSummaryPipeline` rechaza duplicados (`docs/plan_fase5.md`)."""
+
+    repo = _ListRepository(
+        branch_summary_rows=[
+            {
+                "branch_id": 14,
+                "district": "Distrito Alfa",
+                "first_generation_date": None,
+                "first_ccm_arrival": None,
+                "last_ccm_departure": None,
+                "total_missionaries": 10,
+            },
+            {
+                "branch_id": 14,
+                "district": "Distrito Alfa",
+                "first_generation_date": None,
+                "first_ccm_arrival": None,
+                "last_ccm_departure": None,
+                "total_missionaries": 11,
+            },
+        ]
+    )
+
+    pipeline = BranchSummaryPipeline(repository=repo, branch_id=14)
+
+    with pytest.raises(DatasetValidationError) as exc_info:
+        pipeline.prepare()
+
+    assert exc_info.value.error_code == "duplicate_records"
+
+
+def test_upcoming_arrival_pipeline_allows_empty():
+    """ℹ️ `UpcomingArrivalPipeline` respeta `allow_empty=True` (notificaciones)."""
+
+    repo = _ListRepository(upcoming_arrivals_rows=[])
+    pipeline = UpcomingArrivalPipeline(repository=repo, branch_id=14)
+
+    result = pipeline.prepare()
+
+    assert result.metadata.record_count == 0
+    assert result.metadata.dataset_id == "upcoming_arrivals"
+
+
+def test_upcoming_birthday_pipeline_detects_duplicates():
+    """✅ `UpcomingBirthdayPipeline` detecta duplicados relevantes (`docs/plan_fase5.md`)."""
+
+    repo = _ListRepository(
+        upcoming_birthdays_rows=[
+            {
+                "missionary_id": None,
+                "missionary_name": "Élder Ramírez",
+                "birthday": date.today(),
+            },
+            {
+                "missionary_id": None,
+                "missionary_name": "Élder Ramírez",
+                "birthday": date.today(),
+            },
+        ]
+    )
+
+    pipeline = UpcomingBirthdayPipeline(repository=repo, branch_id=14)
+
+    with pytest.raises(DatasetValidationError) as exc_info:
+        pipeline.prepare()
+
+    assert exc_info.value.error_code == "duplicate_records"
+
+
+def test_missing_required_fields_raise_custom_error():
+    """⚠️ `_SimplePipeline` marca `missing_required_fields` cuando faltan campos."""
+
+    pipeline = _SimplePipeline(
+        rows=[
+            {"id": 1, "value": "ok"},
+            {"id": 2, "value": " "},
+            {"id": 3, "value": None},
+        ]
+    )
+
+    with pytest.raises(DatasetValidationError) as exc_info:
+        pipeline.prepare()
+
+    assert exc_info.value.error_code == "missing_required_fields"
+
+
+def test_empty_dataset_without_allow_empty_triggers_error():
+    """⚠️ Las colecciones vacías sin `allow_empty` devuelven `dataset_missing_rows`."""
+
+    pipeline = _SimplePipeline(rows=[])
+
+    with pytest.raises(DatasetValidationError) as exc_info:
+        pipeline.prepare()
+
+    assert exc_info.value.error_code == "dataset_missing_rows"


### PR DESCRIPTION
## ¿Cuál fue el problema?
La preparación de datasets carecía de validaciones completas, pruebas que cubrieran duplicados/rangos/caché y documentación actualizada para la Fase 5.

## ¿Cuál era la causa raíz?
Los pipelines no verificaban ramas autorizadas ni estados de caché obsoletos y la suite de pruebas/documentación no contemplaba los nuevos códigos y métricas requeridas.

## ¿Qué se hizo para resolverlo?
Se reforzaron validaciones y logging en `ReportPreparationService`, se añadieron nuevas pruebas unitarias/modulares con `tests/test_report_validations.py`, y se actualizó la documentación de Fase 5 con métricas, códigos y advertencias vigentes.
