### PR TITLE
Implementa servicio de notificaciones Telegram

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -135,21 +135,21 @@ Este documento detalla el plan de trabajo específico para cada fase del workflo
 ---
 
 ### Fase 6: Generación de Reportes por Telegram
-**Objetivo**: Report Service envía notificaciones push automáticas
-{{ ... }}
+**Objetivo**: Report Service envía notificaciones push automáticas reutilizando los datasets de Fase 5
+
 **Actividades**:
-- ✅ **Configuración de bot**: Token y credenciales de Telegram
-- ✅ **Formateo de mensaje**: Estructura de notificación clara
-- ⏳ **Identificación de destinatarios**: Lista de chats/grupos
-- ⏳ **Envío de notificaciones**: Mensajes push automáticos
-- ⏳ **Manejo de respuestas**: Posible interacción básica
-- ⏳ **Logging de envíos**: Registro de mensajes enviados
+- ✅ **Configuración de bot**: Token y credenciales de Telegram cargadas desde `.env`
+- ✅ **Formateo de mensaje**: Formateadores HTML implementados en `TelegramNotificationService`
+- ℹ️ **Identificación de destinatarios**: Validar lista final de chats/grupos (actualmente se usa `TELEGRAM_CHAT_ID` principal)
+- ✅ **Envío de notificaciones**: Endpoints `/telegram/proximos-ingresos`, `/telegram/proximos-cumpleanos`, `/telegram/alerta` operativos
+- ⏳ **Manejo de respuestas**: Posible interacción básica pendiente
+- ✅ **Logging de envíos**: Logs estructurados `etapa="fase_6_telegram"` en servicio y cliente
 
 **Entregables**:
-- Mensajes enviados exitosamente
-- Notificaciones de distritos que llegan
-- Alertas de próximos cumpleaños
-- Log de interacciones
+- ✅ Servicio `TelegramNotificationService` con Template Method y reintentos
+- ✅ Endpoints FastAPI publicados y cubiertos con pruebas (`tests/integration/test_telegram_endpoints.py`)
+- ✅ Mensajes para próximos ingresos/cumpleaños y alertas con manejo de datasets vacíos
+- ⚠️ Log de interacciones entrantes (para respuestas) pendiente
 
 **Recursos**:
 - Telegram Bot API (`python-telegram-bot`)

--- a/docs/plan_fase6.md
+++ b/docs/plan_fase6.md
@@ -34,6 +34,7 @@ Habilitar un servicio de notificaciones que distribuya por Telegram los reportes
 
 ## Avances recientes
 - **✅ Issue #22**: Cliente base de Telegram implementado en `src/app/services/telegram_client.py`, exportado en `src/app/services/__init__.py`, con pruebas (`src/tests/test_telegram_client.py`) y documentación (`docs/environment_variables.md`).
+- **✅ Issue #23**: `TelegramNotificationService` con Template Method y formateadores específicos (`src/app/services/telegram_notification_service.py`), endpoints FastAPI (`/telegram/proximos-ingresos`, `/telegram/proximos-cumpleanos`, `/telegram/alerta`), pruebas unitarias e integración (`src/tests/test_telegram_notification_service.py`, `tests/integration/test_telegram_endpoints.py`).
 
 ## Dependencias y Preparativos
 - **Datos**: Pipelines `upcoming_arrivals` y `upcoming_birthdays` provistos por Fase 5; vistas MySQL `vwMisioneros`, `vwCumpleanosProximos`.
@@ -68,7 +69,7 @@ Habilitar un servicio de notificaciones que distribuya por Telegram los reportes
 - **Logs** con 100% de mensajes portando `message_id`, `telegram_chat_id` y `records_sent`.
 
 ## Checklist de Coordinación
-- ⚠️ Confirmar variables en `.env` antes de integrar código.
+- ✅ Confirmar variables en `.env` antes de integrar código.
 - ⚠️ Actualizar `docs/plan.md` y `docs/workflow.md` al cerrar subtareas.
-- ⚠️ Registrar avances con símbolos ✅/⚠️/ℹ️ en los reportes al usuario.
-- ⚠️ Mantener concordancia con `scripts_google/` hasta completar migración total.
+- ✅ Registrar avances con símbolos ✅/⚠️/ℹ️ en los reportes al usuario.
+- ✅ Mantener concordancia con `scripts_google/` hasta completar migración total.

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,15 +1,16 @@
 """Servicios disponibles en la aplicación CCM."""
 
-from .validators import TableValidationError, ValidationErrorDetail
+from .validators import validate_email_structure, validate_table_structure
 from .telegram_client import TelegramClient, TelegramSendResult
+from .telegram_notification_service import TelegramNotificationService, TelegramNotificationResult
 
 __all__ = [
     "EmailService",
     "EmailContentUtils",
     "DatabaseSyncService",
     "DatabaseSyncStateRepository",
-    "MissionaryRecord",
-    "ValidationErrorDetail",
+    "validate_email_structure",
+    "validate_table_structure",
     "DriveService",
     "ReportDataRepository",
     "ReportPreparationService",
@@ -18,6 +19,8 @@ __all__ = [
     "RedisCacheStrategy",
     "TelegramClient",
     "TelegramSendResult",
+    "TelegramNotificationService",
+    "TelegramNotificationResult",
 ]
 from .report_preparation_service import (  # noqa: F401
     BaseDatasetPipeline,

--- a/src/app/services/telegram_client.py
+++ b/src/app/services/telegram_client.py
@@ -48,10 +48,11 @@ class TelegramClient:
         transport: Optional[httpx.BaseTransport] = None,
         logger: Optional[structlog.stdlib.BoundLogger] = None,
     ) -> None:
-        if not bot_token:
-            raise ValueError("Se requiere bot_token para inicializar TelegramClient")
-        if not chat_id:
-            raise ValueError("Se requiere chat_id para inicializar TelegramClient")
+        if enabled:
+            if not bot_token:
+                raise ValueError("Se requiere bot_token para inicializar TelegramClient")
+            if not chat_id:
+                raise ValueError("Se requiere chat_id para inicializar TelegramClient")
 
         self._bot_token = bot_token
         self._chat_id = chat_id
@@ -59,7 +60,19 @@ class TelegramClient:
         self._timeout_seconds = timeout_seconds
         self._transport = transport
         self._logger = logger or structlog.get_logger("telegram_service")
-        self._send_endpoint = f"/bot{self._bot_token}/sendMessage"
+        self._send_endpoint = f"/bot{self._bot_token}/sendMessage" if self._bot_token else ""
+
+    @property
+    def enabled(self) -> bool:
+        """Indica si el cliente tiene habilitadas las notificaciones."""
+
+        return self._enabled
+
+    @property
+    def chat_id(self) -> str:
+        """Chat o canal configurado para los envíos."""
+
+        return self._chat_id
 
     def send_message(
         self,

--- a/src/app/services/telegram_notification_service.py
+++ b/src/app/services/telegram_notification_service.py
@@ -48,6 +48,20 @@ class TelegramNotificationService:
         max_attempts: int = 3,
         initial_backoff_seconds: float = 1.0,
     ) -> None:
+        """Inicializa el orquestador de notificaciones hacia Telegram.
+
+        Args:
+            report_service: Fachada que provee los datasets (`UpcomingArrival`,
+                `UpcomingBirthday`, etc.) reutilizados por las notificaciones.
+            telegram_client: Cliente HTTP encargado de ejecutar los envíos hacia
+                la API de Telegram. Debe tener configuradas las credenciales y
+                el chat objetivo.
+            max_attempts: Número máximo de intentos por mensaje cuando la API
+                responde con condiciones recuperables. Se fuerza un mínimo de 1.
+            initial_backoff_seconds: Intervalo inicial (en segundos) para la
+                estrategia de backoff exponencial entre reintentos. Se fuerza un
+                mínimo de 0.1 segundos.
+        """
         self._report_service = report_service
         self._client = telegram_client
         self._max_attempts = max(1, max_attempts)

--- a/src/app/services/telegram_notification_service.py
+++ b/src/app/services/telegram_notification_service.py
@@ -1,0 +1,488 @@
+"""Servicio de notificaciones por Telegram (Fase 6)."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import structlog
+
+from app.logging_utils import bind_log_context, ensure_log_context
+from app.models import ReportDatasetResult
+from app.services.report_preparation_service import (
+    DatasetValidationError,
+    ReportPreparationError,
+    ReportPreparationService,
+)
+from app.services.telegram_client import TelegramClient, TelegramSendResult
+
+
+@dataclass(frozen=True)
+class TelegramNotificationResult:
+    """Resultado de un envío realizado a través del servicio."""
+
+    success: bool
+    telegram_message_id: Optional[int]
+    records_sent: int
+    status_code: int
+    duration_ms: int
+    dataset_id: Optional[str]
+    dataset_records: int
+    dataset_duration_ms: Optional[int]
+    message_id: str
+    error_code: Optional[str]
+    error_description: Optional[str]
+    raw_response: Optional[Dict[str, object]]
+
+
+class TelegramNotificationService:
+    """Orquesta la generación y envío de reportes hacia Telegram."""
+
+    def __init__(
+        self,
+        *,
+        report_service: ReportPreparationService,
+        telegram_client: TelegramClient,
+        max_attempts: int = 3,
+        initial_backoff_seconds: float = 1.0,
+    ) -> None:
+        self._report_service = report_service
+        self._client = telegram_client
+        self._max_attempts = max(1, max_attempts)
+        self._initial_backoff_seconds = max(0.1, initial_backoff_seconds)
+        self._logger = structlog.get_logger("telegram_service")
+
+    # ------------------------------------------------------------------
+    # API pública
+    # ------------------------------------------------------------------
+    def send_upcoming_arrivals(
+        self,
+        *,
+        branch_id: Optional[int] = None,
+        force_refresh: bool = False,
+        days_ahead: int = 60,
+    ) -> TelegramNotificationResult:
+        """Envía reporte de próximos ingresos al CCM."""
+
+        return self._send_dataset_report(
+            dataset_id="upcoming_arrivals",
+            branch_id=branch_id,
+            force_refresh=force_refresh,
+            dataset_fetcher=lambda: self._report_service.prepare_upcoming_arrivals(
+                branch_id=branch_id,
+                force_refresh=force_refresh,
+                days_ahead=days_ahead,
+            ),
+            formatter=self._format_upcoming_arrivals,
+            empty_message="✅ No hay misioneros programados para ingresar al CCM en las próximas semanas.",
+        )
+
+    def send_upcoming_birthdays(
+        self,
+        *,
+        branch_id: Optional[int] = None,
+        force_refresh: bool = False,
+        days_ahead: int = 90,
+    ) -> TelegramNotificationResult:
+        """Envía reporte de próximos cumpleaños."""
+
+        return self._send_dataset_report(
+            dataset_id="upcoming_birthdays",
+            branch_id=branch_id,
+            force_refresh=force_refresh,
+            dataset_fetcher=lambda: self._report_service.prepare_upcoming_birthdays(
+                branch_id=branch_id,
+                force_refresh=force_refresh,
+                days_ahead=days_ahead,
+            ),
+            formatter=self._format_upcoming_birthdays,
+            empty_message="✅ No hay cumpleaños próximos programados para los próximos meses.",
+        )
+
+    def send_alert(
+        self,
+        *,
+        title: str,
+        body: str,
+        level: str = "info",
+        branch_id: Optional[int] = None,
+    ) -> TelegramNotificationResult:
+        """Envía una alerta operativa simple."""
+
+        message_id = datetime.utcnow().strftime("alert%Y%m%d%H%M%S%f")
+        context = ensure_log_context(
+            etapa="fase_6_telegram",
+            message_id=message_id,
+            dataset_id="alert",
+            telegram_chat_id=self._client.chat_id if self._client.chat_id else None,
+            records_processed=0,
+            records_skipped=0,
+        )
+        logger = bind_log_context(self._logger, context)
+
+        logger.info("telegram_alert_started", title=title, level=level)
+
+        text = self._format_alert(title=title, body=body, level=level, branch_id=branch_id)
+        send_result = self._send_with_retries(text=text, message_id=message_id)
+
+        log_event = "telegram_alert_completed" if send_result.success else "telegram_alert_error"
+        logger.info(
+            log_event,
+            telegram_message_id=send_result.telegram_message_id,
+            status_code=send_result.status_code,
+            duration_ms=send_result.duration_ms,
+            error_code=send_result.error_code,
+        )
+
+        return TelegramNotificationResult(
+            success=send_result.success,
+            telegram_message_id=send_result.telegram_message_id,
+            records_sent=send_result.records_sent,
+            status_code=send_result.status_code,
+            duration_ms=send_result.duration_ms,
+            dataset_id="alert",
+            dataset_records=0,
+            dataset_duration_ms=None,
+            message_id=message_id,
+            error_code=send_result.error_code,
+            error_description=send_result.error_description,
+            raw_response=send_result.raw_response,
+        )
+
+    # ------------------------------------------------------------------
+    # Lógica interna
+    # ------------------------------------------------------------------
+    def _send_dataset_report(
+        self,
+        *,
+        dataset_id: str,
+        branch_id: Optional[int],
+        force_refresh: bool,
+        dataset_fetcher: Callable[[], ReportDatasetResult],
+        formatter: Callable[[ReportDatasetResult], str],
+        empty_message: str,
+    ) -> TelegramNotificationResult:
+        if not self._client.enabled:
+            disabled_result = TelegramSendResult(
+                success=False,
+                telegram_message_id=None,
+                records_sent=0,
+                status_code=0,
+                duration_ms=0,
+                should_retry=False,
+                error_code="telegram_disabled",
+                error_description="Las notificaciones de Telegram están deshabilitadas.",
+                raw_response=None,
+            )
+            return TelegramNotificationResult(
+                success=False,
+                telegram_message_id=None,
+                records_sent=0,
+                status_code=0,
+                duration_ms=0,
+                dataset_id=dataset_id,
+                dataset_records=0,
+                dataset_duration_ms=None,
+                message_id="disabled",
+                error_code=disabled_result.error_code,
+                error_description=disabled_result.error_description,
+                raw_response=None,
+            )
+
+        try:
+            dataset_result = dataset_fetcher()
+        except DatasetValidationError as exc:
+            return self._build_failure_result(
+                dataset_id=dataset_id,
+                message_id="dataset_validation_error",
+                error_code=exc.error_code,
+                error_description=str(exc),
+            )
+        except ReportPreparationError as exc:
+            return self._build_failure_result(
+                dataset_id=dataset_id,
+                message_id="dataset_preparation_error",
+                error_code="dataset_error",
+                error_description=str(exc),
+            )
+
+        metadata = dataset_result.metadata
+        message_id = metadata.message_id
+        telegram_chat_id = self._client.chat_id if self._client.chat_id else None
+
+        context = ensure_log_context(
+            etapa="fase_6_telegram",
+            message_id=message_id,
+            dataset_id=dataset_id,
+            branch_id=branch_id,
+            telegram_chat_id=telegram_chat_id,
+            records_processed=metadata.record_count,
+            records_skipped=0,
+        )
+        logger = bind_log_context(self._logger, context)
+
+        logger.info(
+            "telegram_report_started",
+            force_refresh=force_refresh,
+            dataset_records=metadata.record_count,
+        )
+
+        if not metadata.record_count:
+            text = self._format_empty_report(dataset_id=dataset_id, empty_message=empty_message, branch_id=branch_id)
+            send_result = self._send_with_retries(text=text, message_id=message_id)
+            log_event = "telegram_report_completed" if send_result.success else "telegram_report_error"
+            logger.info(
+                log_event,
+                records_sent=send_result.records_sent,
+                status_code=send_result.status_code,
+                duration_ms=send_result.duration_ms,
+                error_code=send_result.error_code,
+            )
+            return TelegramNotificationResult(
+                success=send_result.success,
+                telegram_message_id=send_result.telegram_message_id,
+                records_sent=send_result.records_sent,
+                status_code=send_result.status_code,
+                duration_ms=send_result.duration_ms,
+                dataset_id=dataset_id,
+                dataset_records=metadata.record_count,
+                dataset_duration_ms=metadata.duration_ms,
+                message_id=message_id,
+                error_code=send_result.error_code,
+                error_description=send_result.error_description,
+                raw_response=send_result.raw_response,
+            )
+
+        text = formatter(dataset_result)
+        send_result = self._send_with_retries(text=text, message_id=message_id)
+        log_event = "telegram_report_completed" if send_result.success else "telegram_report_error"
+        logger.info(
+            log_event,
+            records_sent=send_result.records_sent,
+            status_code=send_result.status_code,
+            duration_ms=send_result.duration_ms,
+            error_code=send_result.error_code,
+        )
+
+        return TelegramNotificationResult(
+            success=send_result.success,
+            telegram_message_id=send_result.telegram_message_id,
+            records_sent=send_result.records_sent,
+            status_code=send_result.status_code,
+            duration_ms=send_result.duration_ms,
+            dataset_id=dataset_id,
+            dataset_records=metadata.record_count,
+            dataset_duration_ms=metadata.duration_ms,
+            message_id=message_id,
+            error_code=send_result.error_code,
+            error_description=send_result.error_description,
+            raw_response=send_result.raw_response,
+        )
+
+    def _send_with_retries(self, *, text: str, message_id: str) -> TelegramSendResult:
+        attempt = 0
+        last_result: Optional[TelegramSendResult] = None
+
+        while attempt < self._max_attempts:
+            attempt += 1
+            result = self._client.send_message(text=text, message_id=message_id)
+            if result.success or not result.should_retry:
+                return result
+            last_result = result
+            sleep_seconds = self._initial_backoff_seconds * (2 ** (attempt - 1))
+            time.sleep(sleep_seconds)
+
+        assert last_result is not None  # for mypy/static checkers
+        return last_result
+
+    def _format_empty_report(self, *, dataset_id: str, empty_message: str, branch_id: Optional[int]) -> str:
+        header = self._build_header(dataset_id)
+        footer = self._build_footer(branch_id)
+        return f"{header}{empty_message}\n\n{footer}"
+
+    @staticmethod
+    def _build_header(dataset_id: str) -> str:
+        if dataset_id == "upcoming_arrivals":
+            return "📊 <b>Próximos Ingresos al CCM</b>\n\n"
+        if dataset_id == "upcoming_birthdays":
+            return "🎊 <b>PRÓXIMOS CUMPLEAÑOS</b>\n"
+        return "ℹ️ <b>CCM Notifications</b>\n\n"
+
+    def _build_footer(self, branch_id: Optional[int]) -> str:
+        timestamp = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+        rama = branch_id or self._report_service.default_branch_id or "N/A"
+        return f"🕐 {timestamp}\n🏢 Rama {rama} - CCM Sistema"
+
+    def _format_upcoming_arrivals(self, dataset_result: ReportDatasetResult) -> str:
+        records = dataset_result.data
+        grouped = self._group_arrivals(records)
+        header = self._build_header("upcoming_arrivals")
+        lines: List[str] = [header]
+        today = date.today()
+
+        for arrival_date, entries in grouped:
+            diff_days = (arrival_date - today).days
+            descriptor = self._arrival_time_descriptor(diff_days)
+            formatted_date = arrival_date.strftime("%d/%m/%Y")
+            total = sum(entry["missionaries_count"] for entry in entries)
+            lines.append(f"◆ <b>{descriptor}</b> ({formatted_date})")
+            lines.append(f"◆ Total: {total} misioneros\n")
+
+            for entry in entries:
+                district = entry["district"]
+                rdistrict = entry.get("rdistrict") or "-"
+                lines.append(f"📍 <b>Distrito {district}</b> ({rdistrict})")
+                lines.append(self._format_people_count(entry["missionaries_count"]))
+                duration = entry.get("duration_weeks")
+                if duration:
+                    lines.append(f"⏱️ Duración: {duration} semanas")
+                arrival = arrival_date.strftime("%d/%m/%Y")
+                lines.append(f"◆ Entrada: {arrival}")
+                departure = entry.get("departure_date")
+                if departure:
+                    if isinstance(departure, str):
+                        departure_date = date.fromisoformat(departure)
+                    else:
+                        departure_date = departure
+                    lines.append(f"◆ Salida: {departure_date.strftime('%d/%m/%Y')}")
+                else:
+                    lines.append("◆ Salida: Por definir")
+                lines.append("")
+
+        footer = self._build_footer(dataset_result.metadata.branch_id)
+        lines.append(footer)
+        return "\n".join(lines).strip()
+
+    def _format_upcoming_birthdays(self, dataset_result: ReportDatasetResult) -> str:
+        records = dataset_result.data
+        grouped = self._group_birthdays(records)
+        header = self._build_header("upcoming_birthdays")
+        lines: List[str] = [header]
+        lines.append(f"📅 {datetime.now().strftime('%d/%m/%Y')}")
+        rama = dataset_result.metadata.branch_id or self._report_service.default_branch_id or "N/A"
+        lines.append(f"🎯 Ramas: {rama}\n")
+
+        if not grouped:
+            footer = self._build_footer(dataset_result.metadata.branch_id)
+            lines.append(footer)
+            return "\n".join(lines).strip()
+
+        for month_name, days in grouped:
+            lines.append(f"🗓️ <b>{month_name}</b>:")
+            for day, birthdays in days:
+                for entry in birthdays:
+                    treatment = entry.get("treatment") or entry.get("missionary_name")
+                    age = entry.get("age_turning")
+                    status = entry.get("status") or "CCM"
+                    lines.append(
+                        f"📅 {day:02d} - {treatment} ({age}-{status})"
+                    )
+            lines.append("")
+
+        footer = self._build_footer(dataset_result.metadata.branch_id)
+        lines.append(footer)
+        return "\n".join(lines).strip()
+
+    def _format_alert(self, *, title: str, body: str, level: str, branch_id: Optional[int]) -> str:
+        emoji = {
+            "info": "ℹ️",
+            "warning": "⚠️",
+            "error": "🚨",
+            "success": "✅",
+        }.get(level.lower(), "ℹ️")
+        header = f"{emoji} <b>{title}</b>\n\n"
+        footer = self._build_footer(branch_id)
+        return f"{header}{body}\n\n{footer}"
+
+    @staticmethod
+    def _arrival_time_descriptor(diff_days: int) -> str:
+        if diff_days <= 7:
+            return "La próxima semana"
+        if diff_days <= 14:
+            return "En 2 semanas"
+        if diff_days <= 21:
+            return "En 3 semanas"
+        if diff_days <= 30:
+            return "Este mes"
+        return f"En {diff_days} días"
+
+    @staticmethod
+    def _format_people_count(count: int) -> str:
+        suffix = "s" if count != 1 else ""
+        return f"👥 {count} misionero{suffix}"
+
+    def _group_arrivals(self, records: Iterable[Dict[str, object]]) -> List[Tuple[date, List[Dict[str, object]]]]:
+        groups: Dict[date, List[Dict[str, object]]] = {}
+        for record in records:
+            arrival = record.get("arrival_date")
+            if isinstance(arrival, str):
+                arrival_date = date.fromisoformat(arrival)
+            else:
+                arrival_date = arrival  # type: ignore[assignment]
+            if arrival_date is None:
+                continue
+            key = arrival_date
+            groups.setdefault(key, []).append(record)
+        return sorted((key, groups[key]) for key in groups)
+
+    def _group_birthdays(
+        self, records: Iterable[Dict[str, object]]
+    ) -> List[Tuple[str, List[Tuple[int, List[Dict[str, object]]]]]]:
+        month_names = {
+            1: "ENERO",
+            2: "FEBRERO",
+            3: "MARZO",
+            4: "ABRIL",
+            5: "MAYO",
+            6: "JUNIO",
+            7: "JULIO",
+            8: "AGOSTO",
+            9: "SEPTIEMBRE",
+            10: "OCTUBRE",
+            11: "NOVIEMBRE",
+            12: "DICIEMBRE",
+        }
+        months: Dict[int, Dict[int, List[Dict[str, object]]]] = {}
+        for record in records:
+            birthday = record.get("birthday")
+            if isinstance(birthday, str):
+                birthday_date = date.fromisoformat(birthday)
+            else:
+                birthday_date = birthday  # type: ignore[assignment]
+            if birthday_date is None:
+                continue
+            month = birthday_date.month
+            day = birthday_date.day
+            months.setdefault(month, {}).setdefault(day, []).append(record)
+
+        result: List[Tuple[str, List[Tuple[int, List[Dict[str, object]]]]]] = []
+        for month in sorted(months):
+            days = months[month]
+            day_entries = sorted((day, days[day]) for day in days)
+            result.append((month_names.get(month, str(month)), day_entries))
+        return result
+
+    @staticmethod
+    def _build_failure_result(
+        *,
+        dataset_id: str,
+        message_id: str,
+        error_code: str,
+        error_description: str,
+    ) -> TelegramNotificationResult:
+        return TelegramNotificationResult(
+            success=False,
+            telegram_message_id=None,
+            records_sent=0,
+            status_code=0,
+            duration_ms=0,
+            dataset_id=dataset_id,
+            dataset_records=0,
+            dataset_duration_ms=None,
+            message_id=message_id,
+            error_code=error_code,
+            error_description=error_description,
+            raw_response=None,
+        )

--- a/src/tests/test_telegram_notification_service.py
+++ b/src/tests/test_telegram_notification_service.py
@@ -1,0 +1,318 @@
+"""Pruebas unitarias para `TelegramNotificationService`."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from app.models import ReportDatasetMetadata, ReportDatasetResult
+from app.services.report_preparation_service import DatasetValidationError
+from app.services.telegram_client import TelegramSendResult
+from app.services.telegram_notification_service import (
+    TelegramNotificationResult,
+    TelegramNotificationService,
+)
+
+
+def _build_metadata(
+    *,
+    dataset_id: str,
+    record_count: int,
+    branch_id: Optional[int] = 14,
+    message_id: Optional[str] = None,
+) -> ReportDatasetMetadata:
+    return ReportDatasetMetadata(
+        dataset_id=dataset_id,
+        generated_at=datetime.utcnow(),
+        record_count=record_count,
+        branch_id=branch_id,
+        duration_ms=123,
+        message_id=message_id or "msg-001",
+    )
+
+
+class StubReportPreparationService:
+    """Servicio stub que permite configurar resultados o excepciones por dataset."""
+
+    def __init__(self) -> None:
+        self.calls: Dict[str, int] = {}
+        self._results: Dict[str, ReportDatasetResult] = {}
+        self._exceptions: Dict[str, Exception] = {}
+        self.default_branch_id = 14
+
+    def set_result(self, dataset: str, result: ReportDatasetResult) -> None:
+        self._results[dataset] = result
+
+    def set_exception(self, dataset: str, exc: Exception) -> None:
+        self._exceptions[dataset] = exc
+
+    def prepare_upcoming_arrivals(self, **kwargs: Any) -> ReportDatasetResult:
+        self.calls.setdefault("upcoming_arrivals", 0)
+        self.calls["upcoming_arrivals"] += 1
+        if "upcoming_arrivals" in self._exceptions:
+            raise self._exceptions["upcoming_arrivals"]
+        return self._results["upcoming_arrivals"]
+
+    def prepare_upcoming_birthdays(self, **kwargs: Any) -> ReportDatasetResult:
+        self.calls.setdefault("upcoming_birthdays", 0)
+        self.calls["upcoming_birthdays"] += 1
+        if "upcoming_birthdays" in self._exceptions:
+            raise self._exceptions["upcoming_birthdays"]
+        return self._results["upcoming_birthdays"]
+
+
+class StubTelegramClient:
+    """Cliente Telegram stub que captura mensajes enviados."""
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self.enabled = enabled
+        self.chat_id = "-100123"
+        self.messages: List[Dict[str, Any]] = []
+        self._responses: List[TelegramSendResult] = []
+
+    def queue_response(self, response: TelegramSendResult) -> None:
+        self._responses.append(response)
+
+    def send_message(self, *, text: str, message_id: Optional[str] = None, **kwargs: Any) -> TelegramSendResult:
+        self.messages.append({"text": text, "message_id": message_id})
+        if self._responses:
+            return self._responses.pop(0)
+        return TelegramSendResult(
+            success=True,
+            telegram_message_id=101,
+            records_sent=1,
+            status_code=200,
+            duration_ms=120,
+            should_retry=False,
+            error_code=None,
+            error_description=None,
+            raw_response={"ok": True},
+        )
+
+
+@pytest.fixture
+def stub_service() -> StubReportPreparationService:
+    return StubReportPreparationService()
+
+
+@pytest.fixture
+def stub_client() -> StubTelegramClient:
+    return StubTelegramClient()
+
+
+@pytest.fixture
+def notification_service(
+    stub_service: StubReportPreparationService,
+    stub_client: StubTelegramClient,
+) -> TelegramNotificationService:
+    return TelegramNotificationService(
+        report_service=stub_service,
+        telegram_client=stub_client,
+        max_attempts=3,
+        initial_backoff_seconds=0.01,
+    )
+
+
+def test_send_upcoming_arrivals_success(notification_service: TelegramNotificationService, stub_service: StubReportPreparationService, stub_client: StubTelegramClient) -> None:
+    """Debe enviar un mensaje con el formato esperado para próximos ingresos."""
+
+    metadata = _build_metadata(dataset_id="upcoming_arrivals", record_count=2, message_id="msg-arrivals")
+    dataset_result = ReportDatasetResult(
+        metadata=metadata,
+        data=[
+            {
+                "district": "14A",
+                "rdistrict": "Distrito Alfa",
+                "branch_id": 14,
+                "arrival_date": date.today() + timedelta(days=6),
+                "departure_date": date.today() + timedelta(days=48),
+                "missionaries_count": 5,
+                "duration_weeks": 6,
+            },
+            {
+                "district": "14B",
+                "rdistrict": "Distrito Beta",
+                "branch_id": 14,
+                "arrival_date": date.today() + timedelta(days=6),
+                "departure_date": date.today() + timedelta(days=48),
+                "missionaries_count": 3,
+                "duration_weeks": 6,
+            },
+        ],
+    )
+    stub_service.set_result("upcoming_arrivals", dataset_result)
+
+    result = notification_service.send_upcoming_arrivals()
+
+    assert result.success is True
+    assert result.records_sent == 1
+    assert stub_service.calls["upcoming_arrivals"] == 1
+    assert "Próximos Ingresos" in stub_client.messages[0]["text"]
+    assert "Distrito 14A" in stub_client.messages[0]["text"]
+
+
+def test_send_upcoming_arrivals_empty_dataset(notification_service: TelegramNotificationService, stub_service: StubReportPreparationService, stub_client: StubTelegramClient) -> None:
+    """Cuando el dataset está vacío se envía mensaje positivo informativo."""
+
+    metadata = _build_metadata(dataset_id="upcoming_arrivals", record_count=0, message_id="empty")
+    dataset_result = ReportDatasetResult(metadata=metadata, data=[])
+    stub_service.set_result("upcoming_arrivals", dataset_result)
+
+    result = notification_service.send_upcoming_arrivals()
+
+    assert result.success is True
+    assert "No hay misioneros" in stub_client.messages[0]["text"]
+
+
+def test_send_upcoming_birthdays_groups_by_month(notification_service: TelegramNotificationService, stub_service: StubReportPreparationService, stub_client: StubTelegramClient) -> None:
+    """Verifica que los cumpleaños se agrupen por mes y día."""
+
+    today = date.today()
+    metadata = _build_metadata(dataset_id="upcoming_birthdays", record_count=2, message_id="bday")
+    dataset_result = ReportDatasetResult(
+        metadata=metadata,
+        data=[
+            {
+                "missionary_id": 1,
+                "missionary_name": "Elder Hatcher",
+                "treatment": "Elder Hatcher",
+                "birthday": today.replace(month=11, day=5),
+                "age_turning": 20,
+                "status": "CCM",
+            },
+            {
+                "missionary_id": 2,
+                "missionary_name": "Hermana Perez",
+                "treatment": "Hermana Perez",
+                "birthday": today.replace(month=11, day=6),
+                "age_turning": 21,
+                "status": "Virtual",
+            },
+        ],
+    )
+    stub_service.set_result("upcoming_birthdays", dataset_result)
+
+    result = notification_service.send_upcoming_birthdays()
+
+    assert result.success is True
+    message = stub_client.messages[0]["text"]
+    assert "PRÓXIMOS CUMPLEAÑOS" in message
+    assert "NOVIEMBRE" in message
+    assert "05" in message and "06" in message
+
+
+def test_client_disabled_short_circuits(stub_service: StubReportPreparationService, stub_client: StubTelegramClient) -> None:
+    """Si el cliente está deshabilitado no se consulta el dataset."""
+
+    stub_client.enabled = False
+    notification_service = TelegramNotificationService(
+        report_service=stub_service,
+        telegram_client=stub_client,
+    )
+    result = notification_service.send_upcoming_arrivals()
+
+    assert result.success is False
+    assert stub_service.calls.get("upcoming_arrivals", 0) == 0
+    assert result.error_code == "telegram_disabled"
+
+
+def test_dataset_validation_error(notification_service: TelegramNotificationService, stub_service: StubReportPreparationService) -> None:
+    """Los errores de validación deben propagarse en el resultado."""
+
+    stub_service.set_exception("upcoming_arrivals", DatasetValidationError("boom", error_code="invalid"))
+    result = notification_service.send_upcoming_arrivals()
+
+    assert result.success is False
+    assert result.error_code == "invalid"
+    assert result.error_description == "boom"
+
+
+def test_send_with_retries_until_success(stub_service: StubReportPreparationService) -> None:
+    """Debe reintentar ante respuestas con `should_retry=True`."""
+
+    metadata = _build_metadata(dataset_id="upcoming_arrivals", record_count=1, message_id="retry")
+    dataset_result = ReportDatasetResult(
+        metadata=metadata,
+        data=[
+            {
+                "district": "14A",
+                "rdistrict": "Distrito Alpha",
+                "branch_id": 14,
+                "arrival_date": date.today() + timedelta(days=10),
+                "departure_date": date.today() + timedelta(days=40),
+                "missionaries_count": 4,
+                "duration_weeks": 6,
+            }
+        ],
+    )
+    stub_service.set_result("upcoming_arrivals", dataset_result)
+
+    client = StubTelegramClient()
+    client.queue_response(
+        TelegramSendResult(
+            success=False,
+            telegram_message_id=None,
+            records_sent=0,
+            status_code=500,
+            duration_ms=200,
+            should_retry=True,
+            error_code="telegram_api_error",
+            error_description="too many requests",
+            raw_response={"ok": False},
+        )
+    )
+    client.queue_response(
+        TelegramSendResult(
+            success=True,
+            telegram_message_id=999,
+            records_sent=1,
+            status_code=200,
+            duration_ms=100,
+            should_retry=False,
+            error_code=None,
+            error_description=None,
+            raw_response={"ok": True},
+        )
+    )
+
+    service = TelegramNotificationService(
+        report_service=stub_service,
+        telegram_client=client,
+        max_attempts=3,
+        initial_backoff_seconds=0.01,
+    )
+
+    result = service.send_upcoming_arrivals()
+
+    assert result.success is True
+    assert len(client.messages) == 2
+    assert client.messages[-1]["message_id"] == "retry"
+
+
+def test_empty_birthdays_uses_footer(notification_service: TelegramNotificationService, stub_service: StubReportPreparationService, stub_client: StubTelegramClient) -> None:
+    """Cuando no hay cumpleaños el mensaje debe incluir el footer estándar."""
+
+    metadata = _build_metadata(dataset_id="upcoming_birthdays", record_count=0, message_id="bday-empty")
+    dataset_result = ReportDatasetResult(metadata=metadata, data=[])
+    stub_service.set_result("upcoming_birthdays", dataset_result)
+
+    result = notification_service.send_upcoming_birthdays()
+
+    assert result.success is True
+    message = stub_client.messages[0]["text"]
+    assert "Rama" in message
+    assert message.endswith("CCM Sistema")
+
+
+def test_alert_formatting_uses_level_icon(notification_service: TelegramNotificationService, stub_client: StubTelegramClient) -> None:
+    """Las alertas deben respetar el ícono según severidad."""
+
+    result = notification_service.send_alert(title="Sistema", body="Todo en orden", level="warning")
+
+    assert result.success is True
+    message = stub_client.messages[0]["text"]
+    assert message.startswith("⚠️")
+    assert "Todo en orden" in message
+    assert message.endswith("CCM Sistema")

--- a/tests/integration/test_telegram_endpoints.py
+++ b/tests/integration/test_telegram_endpoints.py
@@ -1,0 +1,120 @@
+"""Pruebas de integración ligeras para los endpoints Telegram."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app, get_telegram_service, telegram_notification_service
+from app.services.telegram_notification_service import TelegramNotificationResult, TelegramNotificationService
+
+
+class DummyTelegramService(TelegramNotificationService):
+    """Servicio de reemplazo que retorna resultados predefinidos."""
+
+    def __init__(self) -> None:  # type: ignore[super-init-not-called]
+        self.calls: Dict[str, Dict[str, object]] = {}
+        self._next_result: Optional[TelegramNotificationResult] = None
+
+    def set_next_result(self, result: TelegramNotificationResult) -> None:
+        self._next_result = result
+
+    def _capture(self, name: str, params: Dict[str, object]) -> None:
+        self.calls[name] = params
+
+    def send_upcoming_arrivals(self, **kwargs) -> TelegramNotificationResult:  # type: ignore[override]
+        self._capture("send_upcoming_arrivals", kwargs)
+        assert self._next_result is not None
+        return self._next_result
+
+    def send_upcoming_birthdays(self, **kwargs) -> TelegramNotificationResult:  # type: ignore[override]
+        self._capture("send_upcoming_birthdays", kwargs)
+        assert self._next_result is not None
+        return self._next_result
+
+    def send_alert(self, **kwargs) -> TelegramNotificationResult:  # type: ignore[override]
+        self._capture("send_alert", kwargs)
+        assert self._next_result is not None
+        return self._next_result
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    dummy_service = DummyTelegramService()
+
+    global telegram_notification_service  # type: ignore[global-variable-not-assigned]
+    original_global = telegram_notification_service
+    telegram_notification_service = dummy_service
+
+    original_override = app.dependency_overrides.get(get_telegram_service)
+    app.dependency_overrides[get_telegram_service] = lambda: dummy_service
+
+    test_client = TestClient(app)
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        telegram_notification_service = original_global
+        if original_override is not None:
+            app.dependency_overrides[get_telegram_service] = original_override
+        else:
+            app.dependency_overrides.pop(get_telegram_service, None)
+
+
+def _result_stub(dataset_id: str = "upcoming_arrivals") -> TelegramNotificationResult:
+    return TelegramNotificationResult(
+        success=True,
+        telegram_message_id=999,
+        records_sent=1,
+        status_code=200,
+        duration_ms=150,
+        dataset_id=dataset_id,
+        dataset_records=3,
+        dataset_duration_ms=120,
+        message_id="test-msg",
+        error_code=None,
+        error_description=None,
+        raw_response={"ok": True},
+    )
+
+
+def test_endpoint_proximos_ingresos(client: TestClient) -> None:
+    service: DummyTelegramService = telegram_notification_service  # type: ignore[assignment]
+    service.set_next_result(_result_stub("upcoming_arrivals"))
+
+    payload = {"branch_id": 14, "force_refresh": True, "days_ahead": 45}
+    response = client.post("/telegram/proximos-ingresos", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert service.calls["send_upcoming_arrivals"]["branch_id"] == 14
+    assert service.calls["send_upcoming_arrivals"]["force_refresh"] is True
+
+
+def test_endpoint_proximos_cumpleanos(client: TestClient) -> None:
+    service: DummyTelegramService = telegram_notification_service  # type: ignore[assignment]
+    service.set_next_result(_result_stub("upcoming_birthdays"))
+
+    payload = {"branch_id": None, "force_refresh": False, "days_ahead": 120}
+    response = client.post("/telegram/proximos-cumpleanos", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dataset_id"] == "upcoming_birthdays"
+    assert service.calls["send_upcoming_birthdays"]["days_ahead"] == 120
+
+
+def test_endpoint_alerta(client: TestClient) -> None:
+    service: DummyTelegramService = telegram_notification_service  # type: ignore[assignment]
+    service.set_next_result(_result_stub("alert"))
+
+    payload = {"title": "Sistema", "body": "Todo en orden", "level": "info"}
+    response = client.post("/telegram/alerta", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dataset_id"] == "alert"
+    assert service.calls["send_alert"]["title"] == "Sistema"

--- a/tests/test_report_preparation_service.py
+++ b/tests/test_report_preparation_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Pruebas unitarias para `ReportPreparationService` y pipelines de Fase 5."""
 
 from dataclasses import dataclass


### PR DESCRIPTION
### ¿Cuál fue el problema?
El flujo de reportes no contaba con un servicio Telegram en Python que reprodujera los avisos de próximos ingresos, cumpleaños y alertas operativas generados previamente desde Apps Script.

### ¿Cuál era la causa raíz?
La fase 6 aún no había sido migrada al nuevo stack; faltaban servicio, formateadores, endpoints y pruebas que reutilizaran los datasets de la fase 5 y respetaran los lineamientos de logging y documentación.

### ¿Qué se hizo para resolverlo?
Se implementó `TelegramNotificationService` con formateadores y reintentos, se expusieron los endpoints `/telegram/proximos-ingresos`, `/telegram/proximos-cumpleanos` y `/telegram/alerta`, se añadieron pruebas unitarias e integrales, y se actualizó la documentación de la fase 6 y el plan general para registrar el nuevo flujo.